### PR TITLE
Implement the functionality to delete a specific job

### DIFF
--- a/app/Http/Controllers/JobController.php
+++ b/app/Http/Controllers/JobController.php
@@ -77,4 +77,14 @@ class JobController extends Controller
       'success' => false
     ], 401);
   }
+
+  public function delete($id) {
+    $job = Job::find($id);
+    $job->delete();
+
+    return response()->json([
+      'message' => 'Job successfully deleted',
+      'success' => true
+    ], 200);
+  }
 }

--- a/routes/web.php
+++ b/routes/web.php
@@ -33,6 +33,11 @@ $router->group(['prefix' => 'api'], function () use ($router) {
             'uses' => 'JobController@create',
             'as' => 'job.create'
         ]);
+
+        $router->delete('/job/{jobId}', [
+            'uses' => 'JobController@delete',
+            'as' => 'job.delete'
+        ]);
     });
 
     $router->get('/jobs', [


### PR DESCRIPTION
#### What does this PR do?
- Implement `DELETE  /api/job/{jobId}` endpoint functionality

#### Description of Task to be completed?
- add route pattern to delete a specific job
- add the logic to delete a specific job

#### How should this be manually tested?
- Clone the repository using `git clone https://github.com/an-apluss/job_listing_API.git` . in your terminal
- run `php -S localhost:8000 -t public` on your terminal to start the server
-  Ensure you login first so as to generate a token, which certifies you as authorized user that can post a job
- include the generated token in the header of your postman like the below format
````
    KEY                               VALUE
    Authorization               Bearer eyJ0eXAiOiJKV1QiLCJhbGciO...
````
- make a `DELETE`  request to the endpoint `localhost:8000/api/job/{jobId}` on postman 
- You should see a response template like below
````
{
      "message": "Job successfully deleted",
      "success": true
 }
````

#### Any background context you want to provide?
- Only Admin can delete a job